### PR TITLE
chore: release v0.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-02-23
+
+### 📦️ Dependencies
+
+- **(deps)** Bump go.abhg.dev/goldmark/mermaid from 0.5.0 to 0.6.0 by @dependabot[bot] in [#67]
+
+[0.2.7]: https://github.com/powerman/md-tasks-notify/compare/v0.2.6..v0.2.7
+[#67]: https://github.com/powerman/md-tasks-notify/pull/67
+
 ## [0.2.6] - 2025-08-21
 
 [0.2.6]: https://github.com/powerman/md-tasks-notify/compare/v0.2.5..v0.2.6


### PR DESCRIPTION

### 📦️ Dependencies

- **(deps)** Bump go.abhg.dev/goldmark/mermaid from 0.5.0 to 0.6.0 by @dependabot[bot] in [#67]

[0.2.7]: https://github.com/powerman/md-tasks-notify/compare/v0.2.6..v0.2.7
[#67]: https://github.com/powerman/md-tasks-notify/pull/67